### PR TITLE
TrackList + Playlist interfaces are optional - don't fatally exit if we can't attach to them

### DIFF
--- a/mpris.js
+++ b/mpris.js
@@ -256,7 +256,9 @@ mc.connect = function (playerName, callback) {
           loadInterface(mc.dbusName, 'org.mpris.MediaPlayer2.TrackList', function (errorTrackList) {
             loadInterface(mc.dbusName, 'org.mpris.MediaPlayer2.Playlists', function (errorPlaylists) {
               watchProperties(mc, mc.dbusName, function (errorWatchProperties) {
-                if(errorBase || errorPlayer || errorTrackList || errorPlaylists || errorWatchProperties ) callback(errorBase+" "+errorPlayer+" "+errorTrackList+" "+errorPlaylists+" "+errorWatchProperties, mc);
+                // Raise an error if we can't get at least the base or player
+                // Other interfaces such as TrackList + Playlists are optional
+                if(errorBase || errorPlayer || errorWatchProperties ) callback(errorBase+" "+errorPlayer+" "+errorTrackList+" "+errorPlaylists+" "+errorWatchProperties, mc);
                 else callback(null, mc);
               });
             });


### PR DESCRIPTION
Most of the bigger media players support all the MPRIS interfaces but some of the smaller ones don't.

This was discovered while trying to attach to the MPRIS interface for [google-music-electron](https://www.npmjs.com/package/google-music-electron).
